### PR TITLE
Add 'nomain' option to the glossary package

### DIFF
--- a/dissertation.tex
+++ b/dissertation.tex
@@ -14,7 +14,7 @@
 % Line spacing package
 \usepackage{graphicx, helvet, hyperref, setspace}
 \usepackage[portuguese,english]{babel}
-\usepackage[acronym, toc]{glossaries}
+\usepackage[nomain, acronym, toc]{glossaries}
 \input{extra_stuff.tex}
 
 % Built the glossary when the main file is built.


### PR DESCRIPTION
Since the glossary is imported from a different file, there is no need to get this warning all the time:

Warning: File 'dissertation.glo' is empty.
Have you used any entries defined in glossary 'main'?
Remember to use package option 'nomain' if you
don't want to use the main glossary.
